### PR TITLE
补充ecosystem/ios.markdown翻译，修复xiaomi.markdown中linkable_title缺失所导致的文档无法编译。

### DIFF
--- a/source/_components/xiaomi.markdown
+++ b/source/_components/xiaomi.markdown
@@ -43,7 +43,7 @@ ha_iot_class: "Local Push"
 
 Follow the setup process using your phone and Mi-Home app. From here you will be able to retrieve the key from within the app following [this tutorial](https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/1832)
 
-### {% linkable_单个网关 %}
+### {% linkable_title 单个网关 %}
 请查看该[章节](/xiaomi/#retrieving-the-access-token)以获取API token。
 
 （译者注：请在米家 app 中与网关配对，之后进入网关页，点选右上角“……” —— 关于 —— 空白处点多下 —— 局域网通信协议 —— 打开并获取密码）
@@ -142,8 +142,8 @@ HA 支持网关铃声的两个操作：播放 `xiaomi.play_ringtone` 和停止`x
 
 That means that Home Assistant is not getting any response from your Xiaomi gateway. Might be a local network problem or your firewall.
 - Make sure you have enabled LAN access: https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/1832
-- Turn off the firewall on the system where Home Assistant is running 
-- Try to leave the MAC address `mac:` blank. 
+- Turn off the firewall on the system where Home Assistant is running
+- Try to leave the MAC address `mac:` blank.
 - Try to set `discovery_retry: 10`
 - Try to disable and then enable LAN access
 
@@ -211,4 +211,3 @@ $ java.exe -jar ../android-backup-extractor/abe.jar unpack backup.ab backup.tar 
 4. Extract this file: **`/raw data/com.xiami.mihome/1234567_mihome.sqlite`** to your computer, where `_1234567_` is any string of numbers.
 5. Open the SQLite database with a tool like SQLite Manager extension for FireFox or DB Browser. You will then see the list of all the devices in your account with their token. The token you need is in the column **`ZToken`** and looks like **`123a1234567b12345c1d123456789e12`**.
 (Location of SQLite files directly on iOS devices **/private/var/mobile/Containers/Data/Application/A80CE9E4-AD2E-4649-8C28-801C96B16BD7/Documents/**)
-

--- a/source/_docs/ecosystem/ios.markdown
+++ b/source/_docs/ecosystem/ios.markdown
@@ -10,52 +10,52 @@ footer: true
 redirect_from: /ecosystem/ios/
 ---
 
-The Home Assistant for iOS app offers a companion app for iOS which is deeply integrated into both Home Assistant and iOS. Its basic features include:
+Home Assistant iOS应用为iOS提供了一个配套的应用程序。它深度融合了Home Assistant和iOS。 其基本功能包括：
 
-* Advanced push notifications
-* Location tracking
-* Basic control of all Home Assistant entities
-* Integration with third party apps
+* 高级推送通知
+* 位置追踪
+* 所有Home Assistant实体的基本控制
+* 第三方应用程序集成
 
-The app is available on the iOS App Store in every country that Apple supports.
+在苹果支持的各个国家/地区的iOS应用商店里，均可下载该应用程序。
 
 <p style="text-align: center;"><a target="_blank" href="https://itunes.apple.com/us/app/home-assistant-open-source-home-automation/id1099568401?mt=8" style="display:inline-block;overflow:hidden;background:url(//linkmaker.itunes.apple.com/assets/shared/badges/en-us/appstore-lrg.svg) no-repeat;width:135px;height:40px;background-size:contain;"></a></p>
 
-## Basic requirements
+## 基本要求
 
-* iOS device running at least iOS 9, but iOS 10 is greatly preferred.
-* Home Assistant 0.42.4 or higher for push notification support.
-* SSL is strongly recommended. Self-signed SSL certificates will not work due to Apple's limitations.
+* iOS设备至少运行iOS 9，但iOS 10更好。
+* Home Assistant 0.42.4或者以上，用以推送通知支持。
+* 强烈建议使用SSL。由于苹果的限制，自签名的SSL证书将无法正常工作。
 
-The `ios` component is the companion component for the Home Assistant iOS app. While not required, adding the `ios` component to your setup will greatly enhance the iOS app with new notification, location and sensor functions not possible with a standalone app.
+`ios`组件是Home Assistant iOS应用的配套组件。虽然不是必须的，但是将`ios`组件添加到您的设置中将大大增强iOS应用程序的功能，其包括新的推送通知，以及不能被独立应用程序所使用的位置和传感器功能。
 
-Loading the `ios` component will also load the [`device_tracker`][device-tracker], [`zeroconf`][zeroconf] and [`notify`][notify] platforms.
+加载`ios`组件会同时加载： [`device_tracker`][device-tracker], [`zeroconf`][zeroconf] 和 [`notify`][notify] 平台.
 
-## {% linkable_title Setup %}
+## {% linkable_title 设置 %}
 
-### Automated Setup
+### 自动设置
 
-The `ios` component will automatically be loaded under the following circumstances:
+在以下情况下，`ios`组件将会被自动加载：
 
-1. The [`discovery`][discovery] component is enabled.
-2. You have just installed the app and are at the getting started screen.
+1. [`discovery`][discovery]组件被启用
+2. 您刚刚安装了应用程序，且刚开始运行。
 
-Automated discovery and component loading only happens at first install of the app. You may need to wait a few minutes for the iOS component to load as the `discovery` component only scans the network every 5 minutes.
+自动发现和组件加载仅在首次安装应用程序时才会发生。因此您可能需要等待几分钟才能加载iOS组件，因为`discovery`组件只有每5分钟的时候才会扫描一次网络。
 
-After the first automated setup you need to add `ios:` to your configuration so that the component loads by default even after restarting Home Assistant.
+第一次自动设置后，您需要在配置文件中添加`ios:`，以便以后重启Home Assistant后，该组件也会被默认加载。
 
-### Manual Setup
+### 手动设置
 
-You may also manually load the `ios` component by adding the following to your configuration:
+您还可以通过在配置文件中添加以下内容来手动加载`ios`组件：
 
 ```yaml
-# Example configuration.yaml entry
+# configuration.yaml接入示例
 ios:
 ```
 
-Configuration variables:
+可配置变量:
 
-- **push** (*Optional*): Actionable push notifications configuration. See the [actionable notifications documentation][actionable-notifications] for more information.
+- **push** (*可选*): 交互式推送通知配置。详情见[交互式通知文件][actionable-notifications]。
 
 [discovery]: /components/discovery
 [device-tracker]: /components/device_tracker


### PR DESCRIPTION
添加ecosystem/ios.markdown翻译，修复xiaomi.markdown中linkable_title缺失导致无法编译错误

